### PR TITLE
Mistory about the yoga slim 7x LID solved.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,4 +8,3 @@ notes:
 
 mysteries:
 - why do some devices reference 0x76, and others 0x36
-- why slim7x lid switch doesn't work


### PR DESCRIPTION
Read https://lore.kernel.org/all/20241219-patch-lenovo-yoga-v3-1-9c4a79068141@mailbox.org/

GPIO pin 71 needs to be on output-disable in order to receive events on pin 92, probably due to the 2 pins being hw bridged.